### PR TITLE
Bug is in osx docker ntp not required

### DIFF
--- a/opg-base-1604/Dockerfile
+++ b/opg-base-1604/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
   && rm /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu
 
-ARG APT_PACKAGES="dos2unix git python-setuptools wget dnsmasq unzip zip netcat netcat-traditional iproute2 ntp ntpdate"
+ARG APT_PACKAGES="dos2unix git python-setuptools wget dnsmasq unzip zip netcat netcat-traditional iproute2"
 
 RUN  rm -f /etc/apt/sources.list.d/* && \
      apt update && \


### PR DESCRIPTION
see https://forums.docker.com/t/time-in-container-is-out-of-sync/16566/12

local test

OSX 5 ~ minute sleep
```
$ docker exec front date && date
Wed May 24 08:14:13 UTC 2017
Wed 24 May 2017 09:18:11 BST
```

Debian Jessie ~ 5 minute sleep
```
> docker exec front date && date
Wed May 24 08:17:11 UTC 2017
Wed 24 May 09:17:11 BST 2017
```