### PR TITLE
SDV2-1061 Consider `SSL_CERT_COMMON_NAME` variable 

### DIFF
--- a/opg-base-1604/README.md
+++ b/opg-base-1604/README.md
@@ -53,6 +53,7 @@ Supported variables
 -------------------
 * OPG_DOCKER_TAG - see versions
 * SKIP_SSL_GENERATE - when set container will not create self signed certificate on start
+* SSL_CERT_COMMON_NAME - if set, its value will be used for `common name` while generating the self signed certificate 
 * OPG_BASE_SSL_CERT - pass a cert as a multiline or using `"\n"`
 * OPG_BASE_SSL_KEY - pass a key as a multiline or using `"\n"`
 

--- a/opg-base-1604/docker/my_init.d/99-generate-ssl
+++ b/opg-base-1604/docker/my_init.d/99-generate-ssl
@@ -17,7 +17,8 @@ cp key.pem key.pem.orig
 openssl rsa -passin pass:x -in key.pem.orig -out key.pem
 
 # Generating certificate signing request
-openssl req -new -key key.pem -out cert.csr -subj "/C=GB/ST=GB/L=London/O=OPG/OU=Digital/CN=default"
+openssl req -new -key key.pem -out cert.csr -subj \
+"/C=GB/ST=GB/L=London/O=OPG/OU=Digital/CN=${SSL_CERT_COMMON_NAME:=default}"
 
 # Generating self-signed certificate
 openssl x509 -req -days 3650 -in cert.csr -signkey key.pem -out cert.pem


### PR DESCRIPTION
when/if we are generating a self signed certificate